### PR TITLE
Fix RegExp pattern for windows

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     '^.+\\.js$': '<rootDir>/node_modules/babel-jest',
     '^(?!.*\\.(js|json)$)': '<rootDir>/config/jest/fileTransform.js',
   },
-  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.js$'],
+  transformIgnorePatterns: ['/node_modules/.+\\.js$'],
   moduleFileExtensions: ['js', 'json', 'node'],
   moduleNameMapper: {
     '^@assets(.*)$': '<rootDir>/src/assets',


### PR DESCRIPTION
Hi there, 

First, thanks for the starter. A lot of things to learn for me.

I've found an issue.

I'm on Windows and the `yarn test` command returns an error.
I don't know why but the RexExp pattern assinged to the `transformIgnorePatterns` property in `jest.config.js`,

```
transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.js$'],
```

somewhere along the line, is transformed to `[\\\\\]node_modules[\\\\\]`.

![yarn-test-error](https://raw.githubusercontent.com/greglobinski/notebook/master/2018-06/daftcode-react-pro/screenshots/yarn-test-error.png)

A change to

```
transformIgnorePatterns: ['[\\\\/]node_modules[\\\\/].+\\.js$'],
```

removes the error. But also a change like this does.

```
transformIgnorePatterns: ['/node_modules/.+\\.js$'],
```
