### PR TITLE
Fix webp support test

### DIFF
--- a/src/view/hero/HeroBanner.js
+++ b/src/view/hero/HeroBanner.js
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import HeroBackground from '@assets/images/heroBackgroud.jpg';
 import HeroBackgroundWebp from '@assets/images/heroBackgroud.webp';
 
+const modernizr = require('modernizr');
+
 const HeroContainer = styled.div`
   position: relative;
   width: 100%;
@@ -16,10 +18,8 @@ const HeroImage = styled.div`
   width: 100vw;
   height: 100vh;
   background-size: cover;
-  background-image: url(${HeroBackground});
-  @supports (background-image: url(${HeroBackgroundWebp})) {
-    background-image: url(${HeroBackgroundWebp});
-  }
+  background-image: url(${props =>
+    props.webp === undefined ? '' : props.webp === false ? HeroBackground : HeroBackgroundWebp});
 `;
 
 const HeroContent = styled.div`
@@ -34,13 +34,41 @@ const HeroContent = styled.div`
   justify-content: center;
 `;
 
-const HeroBanner = ({ image, min, max, children }: any) => (
-  <HeroContainer>
-    <Parallax offsetYMin={min} offsetYMax={max} slowerScrollRate={true}>
-      <HeroImage />
-    </Parallax>
-    <HeroContent>{children}</HeroContent>
-  </HeroContainer>
-);
+class HeroBanner extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      webp: undefined,
+    };
+
+    this.testWebpSupport().then(result => this.setState({ webp: result }));
+  }
+
+  testWebpSupport = () => {
+    return new Promise(function(resolve, reject) {
+      modernizr.on('webp', function(result) {
+        if (result) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      });
+    });
+  };
+
+  render() {
+    const { min, max, children } = this.props;
+
+    return (
+      <HeroContainer>
+        <Parallax offsetYMin={min} offsetYMax={max} slowerScrollRate={true}>
+          <HeroImage webp={this.state.webp} />
+        </Parallax>
+        <HeroContent>{children}</HeroContent>
+      </HeroContainer>
+    );
+  }
+}
 
 export default HeroBanner;


### PR DESCRIPTION
Firefox is cheating that it supports Webp

Firefox (v. 60.0.2 on windows) mistakenly answers to the `@supports` test. 
It says it does...

```
  @supports (background-image: url(${HeroBackgroundWebp})) {
    background-image: url(${HeroBackgroundWebp});
  }
```

but then do not render `.webp` images and we stay with empty backgorund.

![firefox-webp](https://raw.githubusercontent.com/greglobinski/notebook/master/2018-06/daftcode-react-pro/screenshots/firefox-webp.png)

I've used Moternizr to test the support.