### PR TITLE
Picture's media conditions moved to a `sizes` atribute

### DIFF
--- a/src/view/contact/Contact.js
+++ b/src/view/contact/Contact.js
@@ -21,28 +21,24 @@ type ContactProps = {};
 class Contact extends React.Component<ContactProps> {
   renderAvatar = () => {
     return (
-      <picture>
-        {/* Portrait Phones  - WEBP*/}
-        <source media="(max-width: 767px)" srcSet={castle_ar_1_1_c_fill___auto__c_scale_w_200_webp} type="image/webp" />
-        {/* Tablets  - WEBP*/}
-        <source
-          media="(min-width: 768px) and (max-width: 991px)"
-          srcSet={castle_ar_4_3_c_fill_g_auto__c_scale_w_538_webp}
-          type="image/webp"
-        />
-        {/* Desktops  - WEBP*/}
-        <source
-          media="(min-width: 992px)"
-          srcSet={castle_ar_16_9_c_fill_g_auto__c_scale_w_874_webp}
-          type="image/webp"
-        />
-        {/* Portrait Phones */}
-        <source media="(max-width: 767px)" srcSet={castle_ar_1_1_c_fill___auto__c_scale_w_200} />
-        {/* Tablets */}
-        <source media="(min-width: 768px) and (max-width: 991px)" srcSet={castle_ar_4_3_c_fill_g_auto__c_scale_w_538} />
-        {/* Desktops */}
-        <img media="(min-width: 992px)" srcSet={castle_ar_16_9_c_fill_g_auto__c_scale_w_874} alt="" />
-      </picture>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset={`${castle_ar_1_1_c_fill___auto__c_scale_w_200_webp} 200w,
+              ${castle_ar_4_3_c_fill_g_auto__c_scale_w_538_webp} 538w,
+              ${castle_ar_16_9_c_fill_g_auto__c_scale_w_874_webp} 874w`}
+            sizes="(max-width: 767px) 200px, (max-width: 991px) 538px, 874px"
+          />
+          <source
+            srcset={`${castle_ar_1_1_c_fill___auto__c_scale_w_200} 200w,
+              ${castle_ar_4_3_c_fill_g_auto__c_scale_w_538} 538w,
+              ${castle_ar_16_9_c_fill_g_auto__c_scale_w_874} 874w`}
+            sizes="(max-width: 767px) 200px, (max-width: 991px) 538px, 874px"
+          />
+          <img src={castle_ar_16_9_c_fill_g_auto__c_scale_w_874} alt="" />
+        </picture>
+      </div>
     );
   };
 


### PR DESCRIPTION
There is nothing wrong with the original code

```
<picture>
  <source media="(max-width: 767px)" srcSet={castle_ar_1_1_c_fill___auto__c_scale_w_200_webp} type="image/webp" />
  <source
    media="(min-width: 768px) and (max-width: 991px)"
    srcSet={castle_ar_4_3_c_fill_g_auto__c_scale_w_538_webp}
    type="image/webp"
  />
  <source media="(min-width: 992px)" srcSet={castle_ar_16_9_c_fill_g_auto__c_scale_w_874_webp} type="image/webp" />
  <source media="(max-width: 767px)" srcSet={castle_ar_1_1_c_fill___auto__c_scale_w_200} />
  <source media="(min-width: 768px) and (max-width: 991px)" srcSet={castle_ar_4_3_c_fill_g_auto__c_scale_w_538} />
  <img media="(min-width: 992px)" srcSet={castle_ar_16_9_c_fill_g_auto__c_scale_w_874} alt="" />
</picture>
```

but I believe that this one, is more readable.

```
<picture>
  <source
    type="image/webp"
    srcset={`${castle_ar_1_1_c_fill___auto__c_scale_w_200_webp} 200w,
    ${castle_ar_4_3_c_fill_g_auto__c_scale_w_538_webp} 538w,
    ${castle_ar_16_9_c_fill_g_auto__c_scale_w_874_webp} 874w`}
    sizes="(max-width: 767px) 200px, (max-width: 991px) 538px, 874px"
  />
  <source
    srcset={`${castle_ar_1_1_c_fill___auto__c_scale_w_200} 200w,
    ${castle_ar_4_3_c_fill_g_auto__c_scale_w_538} 538w,
    ${castle_ar_16_9_c_fill_g_auto__c_scale_w_874} 874w`}
    sizes="(max-width: 767px) 200px, (max-width: 991px) 538px, 874px"
  />
  <img src={castle_ar_16_9_c_fill_g_auto__c_scale_w_874} alt="" />
</picture>;
```

Although the new code doesn't work 100% the same way as yours. When you are on desktop and you manualy resize the window, Google Chrome does not update image sources when you make the window smaller, when you make it bigger it does. I don't know it's a bug or intentional behaviour.

Once again thank you for the starter. It'll be a source of the new knowledge for me for some time.